### PR TITLE
Reboot with shutdown on Windows

### DIFF
--- a/rootAVD.bat
+++ b/rootAVD.bat
@@ -136,7 +136,7 @@ if "%ERRORLEVEL%"=="1" (
 
 			call :installapps
 
-			echo [-] reboot the AVD and see if it worked
+			echo [-] reboot the AVD ('adb shell reboot -p' then restart) and see if it worked (Run Magisk, 'Requires Additional Setup' window prompted)
 			echo [-] Root and Su with Magisk for Android Studio AVDs
 			echo [-] Modded by NewBit XDA - Jan. 2021
 			echo [*] Huge Credits and big Thanks to topjohnwu and shakalaca


### PR DESCRIPTION
Firstly, many many thanks for your work 😗.
After spent a lot of time to try to have an emulated Android rooted with Google Playstore, this project is just amazing 🤩.

A very minor contribution ... but on Windows 10 with Android Studio 2020.3.1, I had some difficulties to gain (emulator root at reboot), many tries on many system images without results, including [succesfully tested](https://github.com/newbit1/rootAVD#magisk-v221-successfully-tested-with-stock-kernel-on).

The solution is just to shutdown (`adb shell reboot -p`) ... and it works like a charm.
