### PR TITLE
fix missing quotes to make script work under windows with spaces in the folder path

### DIFF
--- a/rootAVD.bat
+++ b/rootAVD.bat
@@ -85,7 +85,7 @@ adb shell rm -rf %ADBBASEDIR%
 echo [*] Creating the ADB working space
 adb shell mkdir %ADBBASEDIR%
 
-call :pushtoAVD %MAGISKZIP%
+call :pushtoAVD "%MAGISKZIP%"
 REM Proceed with ramdisk
 set INITRAMFS=%ROOTAVD%\initramfs.img
 if %RAMDISKIMG% (


### PR DESCRIPTION
This PR fixes a problem when running the script from a folder with a space in the folder path.

The error eventually results in the message "[!] AVD is offline".

The cause is a missing encapsulation of the Windows folder path in quotes when trying to push the Magisk.zip into the AVD.